### PR TITLE
GK1H-T1.21.1NF 1.3.1 - Vein Mining

### DIFF
--- a/MPUC/meta.json
+++ b/MPUC/meta.json
@@ -105,7 +105,7 @@
       },
       {
         "id": "1.3.1",
-        "releasedAt": 987654321098765,
+        "releasedAt": 1758891926000,
         "updateType":"minor_breaking",
         "promotions": {
           "downloads": {

--- a/MPUC/meta.json
+++ b/MPUC/meta.json
@@ -102,6 +102,17 @@
             "generic": "https://github.com/Gameking1happy-Development/GK1H-T1.21.1NF/releases/tag/1.3.0/"
           }
         }
+      },
+      {
+        "id": "1.3.1",
+        "releasedAt": 987654321098765,
+        "updateType":"minor_breaking",
+        "promotions": {
+          "downloads": {
+            "modrinth": "https://modrinth.com/modpack/gk1h-t1.21.1nf/version/1.3.1/",
+            "generic": "https://github.com/Gameking1happy-Development/GK1H-T1.21.1NF/releases/tag/1.3.1/"
+          }
+        }
       }
     ]
   }

--- a/MPUC/versions/1.3.1/changelog.txt
+++ b/MPUC/versions/1.3.1/changelog.txt
@@ -1,0 +1,13 @@
+# GK1H-T1.21.1NF 1.3.1 - Vein Mining
+
+## Mod Additions
+
+Vein Mining
+
+## Mod Updates
+
+Just Enough Items (19.25.0.319 to 19.25.0.321)
+
+## Current Issues
+
+Totem of Neverdying (from Netherite Extras) cannot be equipped in the charm slot, despite Charm of Undying having Fabric compat with it. The regular Totem of Undying can be equipped in the charm slot and has no problems. When making 1.3.1 I attempted using the Fabric version, but it is broken on NeoForge.


### PR DESCRIPTION
# GK1H-T1.21.1NF 1.3.1 - Vein Mining  
## Mod Additions  
Vein Mining  
## Mod Updates  
Just Enough Items (19.25.0.319 to 19.25.0.321)  
## Current Issues  
Totem of Neverdying (from Netherite Extras) cannot be equipped in the charm slot, despite Charm of Undying having Fabric compat with it. The regular Totem of Undying can be equipped in the charm slot and has no problems. When making 1.3.1 I attempted using the Fabric version, but it is broken on NeoForge.