### PR TITLE
GK1H-T1.21.1NF 1.3.2 - Advanced Netherite Update

### DIFF
--- a/MPUC/meta.json
+++ b/MPUC/meta.json
@@ -113,6 +113,17 @@
             "generic": "https://github.com/Gameking1happy-Development/GK1H-T1.21.1NF/releases/tag/1.3.1/"
           }
         }
+      },
+      {
+        "id": "1.3.2",
+        "releasedAt": 987654321098765,
+        "updateType":"minor_breaking",
+        "promotions": {
+          "downloads": {
+            "modrinth": "https://modrinth.com/modpack/gk1h-t1.21.1nf/version/1.3.2/",
+            "generic": "https://github.com/Gameking1happy-Development/GK1H-T1.21.1NF/releases/tag/1.3.2/"
+          }
+        }
       }
     ]
   }

--- a/MPUC/meta.json
+++ b/MPUC/meta.json
@@ -116,7 +116,7 @@
       },
       {
         "id": "1.3.2",
-        "releasedAt": 987654321098765,
+        "releasedAt": 1758916218000,
         "updateType":"minor_breaking",
         "promotions": {
           "downloads": {

--- a/MPUC/versions/1.3.2/changelog.txt
+++ b/MPUC/versions/1.3.2/changelog.txt
@@ -1,12 +1,12 @@
-# GK1H-T1.21.1NF 1.3.1 - Vein Mining
+# GK1H-T1.21.1NF 1.3.2 - Advanced Netherite Update
 
 ## Mod Additions
 
-Vein Mining
+Advanced Netherite
 
-## Mod Updates
+Netherited
 
-Just Enough Items (19.25.0.319 to 19.25.0.321)
+Load My F\*\*\*ing Tags
 
 ## Current Issues
 


### PR DESCRIPTION
# GK1H-T1.21.1NF 1.3.2 - Advanced Netherite Update  
## Mod Additions  
Advanced Netherite  
Netherited  
Load My F\*\*\*ing Tags  
## Current Issues  
Totem of Neverdying (from Netherite Extras) cannot be equipped in the charm slot, despite Charm of Undying having Fabric compat with it. The regular Totem of Undying can be equipped in the charm slot and has no problems. When making 1.3.1, I attempted using the Fabric version, but it is broken on NeoForge.