### PR TITLE
GK1H-T1.21.1NF 1.3.3 - Accessorify Update

### DIFF
--- a/MPUC/meta.json
+++ b/MPUC/meta.json
@@ -124,6 +124,17 @@
             "generic": "https://github.com/Gameking1happy-Development/GK1H-T1.21.1NF/releases/tag/1.3.2/"
           }
         }
+      },
+      {
+        "id": "1.3.3",
+        "releasedAt": 1758988136000,
+        "updateType":"minor_breaking",
+        "promotions": {
+          "downloads": {
+            "modrinth": "https://modrinth.com/modpack/gk1h-t1.21.1nf/version/1.3.3/",
+            "generic": "https://github.com/Gameking1happy-Development/GK1H-T1.21.1NF/releases/tag/1.3.3/"
+          }
+        }
       }
     ]
   }

--- a/MPUC/versions/1.3.3/changelog.txt
+++ b/MPUC/versions/1.3.3/changelog.txt
@@ -1,0 +1,19 @@
+# GK1H-T1.21.1NF 1.3.3 - Accessorify Update
+
+## Mod Additions
+
+Accessorify
+
+## Mod Removals
+
+Elytra Slot
+
+Charm of Undying
+
+## Mod Updates
+
+YetAnotherConfigLib (YACL) (3.7.1 to 3.8.0)
+
+## New Issues
+
+Totem of Neverdying (from Netherite Extras) cannot be equipped in the charm slot. Accessiorify does not currently have compatibility with Netherite Extras. I have opened an issue on their GitHub to see if they can add compatibility. In the meantime, you can use the totem in your offhand or main hand.


### PR DESCRIPTION
# GK1H-T1.21.1NF 1.3.3 - Accessorify Update
## Mod Additions
Accessorify
## Mod Removals
Elytra Slot
Charm of Undying
## Mod Updates
YetAnotherConfigLib (YACL) (3.7.1 to 3.8.0)
## New Issues
Totem of Neverdying (from Netherite Extras) cannot be equipped in the charm slot. Accessiorify does not currently have compatibility with Netherite Extras. I have opened an issue on their GitHub to see if they can add compatibility. In the meantime, you can use the totem in your offhand or main hand.